### PR TITLE
Fix invalid template file

### DIFF
--- a/view/adminhtml/layout/sales_order_view.xml
+++ b/view/adminhtml/layout/sales_order_view.xml
@@ -2,7 +2,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="order_info">
-            <block class="Magento\Backend\Block\Template" name="customer_comment" template="order/customer_comment.phtml"/>
+            <block class="Magento\Backend\Block\Template" name="customer_comment" template="METMEER_CustomerComment::order/customer_comment.phtml"/>
         </referenceBlock>
     </body>
 </page>


### PR DESCRIPTION
In Magento v2.2 the template file should be prefixed with the module name, otherwise an exception appears:

1 exception(s):
Exception #0 (Magento\Framework\Exception\ValidatorException): Invalid template file: 'order/customer_comment.phtml' in module: 'Magento_Backend' block's name: 'customer_comment'